### PR TITLE
Import MunkRes module error 

### DIFF
--- a/python/pyhrf/test/test_parcellation.py
+++ b/python/pyhrf/test/test_parcellation.py
@@ -136,8 +136,9 @@ class ParcellationMethodTest(unittest.TestCase):
                             [0,2,2,2],
                             [0,0,2,4]], dtype=np.int32)
 
-    @unittest.skipIf(not tools.is_importable('sklearn'),
-                     'scikit-learn (optional dep) is N/A')
+    @unittest.skipIf(not tools.is_importable('sklearn') or
+                     not tools.is_importable('munkres'),
+                     'scikit-learn or munkres (optional deps) is N/A')
     def test_ward_spatial_scikit(self):
         from pyhrf.parcellation import parcellation_dist, \
                parcellation_ward_spatial
@@ -158,8 +159,9 @@ class ParcellationMethodTest(unittest.TestCase):
         dist = parcellation_dist(self.p1+1, labels+1)[0] #+1 because parcellation_dist sees 0 as background
         self.assertEqual(dist, 0)
 
-    @unittest.skipIf(not tools.is_importable('sklearn'),
-                     'scikit-learn (optional dep) is N/A')
+    @unittest.skipIf(not tools.is_importable('sklearn') or
+                     not tools.is_importable('munkres'),
+                     'scikit-learn or munkres (optional deps) is N/A')
     def test_ward_spatial_scikit_with_mask(self):
         from pyhrf.parcellation import parcellation_dist, parcellation_ward_spatial
         from pyhrf.graph import graph_from_lattice, kerMask2D_4n
@@ -215,8 +217,9 @@ class CmdParcellationTest(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.tmp_dir)
 
-    @unittest.skipIf(not tools.is_importable('sklearn'),
-                     'scikit-learn (optional dep) is N/A')
+    @unittest.skipIf(not tools.is_importable('sklearn') or
+                     not tools.is_importable('munkres'),
+                     'scikit-learn or munkres (optional deps) is N/A')
     def test_ward_spatial_cmd(self):
         from pyhrf.parcellation import parcellation_dist
 
@@ -239,8 +242,9 @@ class CmdParcellationTest(unittest.TestCase):
         self.assertEqual(dist, 0)
 
 
-    @unittest.skipIf(not tools.is_importable('sklearn'),
-                     'scikit-learn (optional dep) is N/A')
+    @unittest.skipIf(not tools.is_importable('sklearn') or
+                     not tools.is_importable('munkres'),
+                     'scikit-learn or munkres (optional deps) is N/A')
     def test_ward_spatial_real_data(self):
         from pyhrf.glm import glm_nipy_from_files
         #pyhrf.verbose.verbosity = 2


### PR DESCRIPTION
# 
## ERROR: test_ward_spatial_cmd (pyhrf.test.test_parcellation.CmdParcellationTest)

Traceback (most recent call last):
  File "/volatile/ciuciu/pyhrf/python/pyhrf/test/test_parcellation.py", line 237, in test_ward_spatial_cmd
    dist = parcellation_dist(self.p1, labels)[0]
  File "/volatile/ciuciu/pyhrf/python/pyhrf/parcellation.py", line 998, in parcellation_dist
    from munkres import Munkres
ImportError: No module named munkres
# 
## ERROR: test_ward_spatial_scikit (pyhrf.test.test_parcellation.ParcellationMethodTest)

Traceback (most recent call last):
  File "/volatile/ciuciu/pyhrf/python/pyhrf/test/test_parcellation.py", line 158, in test_ward_spatial_scikit
    dist = parcellation_dist(self.p1+1, labels+1)[0] #+1 because parcellation_dist sees 0 as background
  File "/volatile/ciuciu/pyhrf/python/pyhrf/parcellation.py", line 998, in parcellation_dist
    from munkres import Munkres
ImportError: No module named munkres
# 
## ERROR: test_ward_spatial_scikit_with_mask (pyhrf.test.test_parcellation.ParcellationMethodTest)

Traceback (most recent call last):
  File "/volatile/ciuciu/pyhrf/python/pyhrf/test/test_parcellation.py", line 188, in test_ward_spatial_scikit_with_mask
    dist = parcellation_dist(self.p1+1, labels+1)[0]
  File "/volatile/ciuciu/pyhrf/python/pyhrf/parcellation.py", line 998, in parcellation_dist
    from munkres import Munkres
ImportError: No module named munkres
