### PR TITLE
[Closes #86, Closes #103, Closes #104] Remove snapshot scripts, fix for minimal dependencies and fix for matplolib non-interactive backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ before_install:
     - pip install coveralls
     # set non-interactive matplotlib backend to avoid issues related to $DISPLAY
     # not found
-    - wget -q http://matplotlib.org/1.3.1/_static/matplotlibrc
-    - sed -i.bak  's/^backend.*/backend:Agg/' matplotlibrc
+    # - wget -q http://matplotlib.org/1.3.1/_static/matplotlibrc
+    # - sed -i.bak  's/^backend.*/backend:Agg/' matplotlibrc
 # command to install dependencies
 # e.g. pip install -r requirements.txt # --use-mirrors
 install:

--- a/bin/pyhrf_plot_slice
+++ b/bin/pyhrf_plot_slice
@@ -3,6 +3,7 @@
 
 import sys
 import logging
+import os
 import os.path as op
 
 from optparse import OptionParser
@@ -12,6 +13,14 @@ import pyhrf
 from pyhrf.ndarray import xndarray
 
 logger = logging.getLogger(__name__)
+
+try:
+    os.environ['DISPLAY']
+except KeyError:
+    # Non interactive terminal
+    # Let's disable graphical backend for matplotlib
+    import matplotlib
+    matplotlib.use('Agg')
 
 usage = 'usage: %%prog [options] VOL_FILE'
 description = 'Plot slice(s) of a given volume '

--- a/python/pyhrf/sandbox/parcellation.py
+++ b/python/pyhrf/sandbox/parcellation.py
@@ -25,12 +25,28 @@ try:
     from scipy.maxentropy import logsumexp
 except ImportError:
     from scipy.misc import logsumexp
-from sklearn.base import BaseEstimator, ClusterMixin
 from scipy.sparse import cs_graph_components
-from sklearn.externals.joblib import Memory
-from sklearn.metrics import euclidean_distances
-from sklearn.utils import array2d
-from sklearn.cluster._feature_agglomeration import AgglomerationTransform
+try:
+    from sklearn.base import BaseEstimator, ClusterMixin
+    from sklearn.externals.joblib import Memory
+    from sklearn.metrics import euclidean_distances
+    from sklearn.utils import array2d
+    from sklearn.cluster._feature_agglomeration import AgglomerationTransform
+    from sklearn.mixture import GMM
+    from sklearn.cluster import Ward as WardSK
+except ImportError:
+    class BaseEstimator(object):
+        pass
+    class ClusterMixin(object):
+        pass
+    def Memory(*args, **kwargs):
+        pass
+    class AgglomerationTransform(object):
+        pass
+    # This is only for tests including doctests (since nose try to import
+    # everything) in the case of minimal requirements (without scikit-learn)
+    # TODO: find a better way of handling this case (or make sklearn a required
+    # dependency)
 
 import pyhrf
 
@@ -323,7 +339,6 @@ def compute_mixt_dist(features, alphas, coord_row, coord_col, cluster_masks,
     return res
 
 
-from sklearn.mixture import GMM
 
 
 def compute_mixt_dist_skgmm(features, alphas, coord_row, coord_col,
@@ -1515,7 +1530,6 @@ def feature_extraction(fmri_data, method, dt=.5, time_length=25., ncond=1):
 import pyhrf.graph as pgraph
 
 
-from sklearn.cluster import Ward as WardSK
 
 
 def spatial_ward_sk(features, graph, nb_clusters=0):

--- a/python/pyhrf/test/test_ndarray.py
+++ b/python/pyhrf/test/test_ndarray.py
@@ -9,6 +9,12 @@ import difflib
 import numpy as np
 import numpy.testing as npt
 
+try:
+    os.environ["DISPLAY"]
+except KeyError:
+    import matplotlib
+    matplotlib.use("Agg")
+
 from pyhrf.ndarray import *
 from pyhrf.tools import add_suffix
 

--- a/python/pyhrf/test/test_plot.py
+++ b/python/pyhrf/test/test_plot.py
@@ -8,6 +8,12 @@ import shutil
 import pyhrf
 from pyhrf.plot import plot_cub_as_curve, plot_cub_as_image
 
+try:
+    os.environ["DISPLAY"]
+except KeyError:
+    import matplotlib
+    matplotlib.use("Agg")
+
 import matplotlib.pyplot as plt
 
 from pyhrf.ndarray import xndarray

--- a/python/pyhrf/test/test_sandbox_physio.py
+++ b/python/pyhrf/test/test_sandbox_physio.py
@@ -14,6 +14,7 @@ import pyhrf
 import pyhrf.sandbox.physio as phy
 
 from pyhrf import Condition
+from pyhrf.tools import is_importable
 
 
 logger = logging.getLogger(__name__)
@@ -32,6 +33,7 @@ class SimulationTest(unittest.TestCase):
             logger.info('cleaning temporary folder ...')
             shutil.rmtree(self.tmp_path)
 
+    @unittest.skipUnless(is_importable("PIL"), "Pillow (optional dep) is N/A")
     def test_simulate_asl_full_physio(self):
 
         # pyhrf.verbose.set_verbosity(0)
@@ -49,6 +51,7 @@ class SimulationTest(unittest.TestCase):
         # self.assertEqual(r['bold'].shape, (297, 4)) #nb scans, flat spatial
         # axis
 
+    @unittest.skipUnless(is_importable("PIL"), "Pillow (optional dep) is N/A")
     def test_simulate_asl_full_physio_outputs(self):
 
         # pyhrf.verbose.set_verbosity(0)
@@ -62,6 +65,7 @@ class SimulationTest(unittest.TestCase):
         self.assertTrue(op.exists(makefn('flow_induction.nii')))
         self.assertTrue(op.exists(makefn('neural_efficacies_audio.nii')))
 
+    @unittest.skipUnless(is_importable("PIL"), "Pillow (optional dep) is N/A")
     def test_simulate_asl_physio_rfs(self):
 
         # pyhrf.verbose.set_verbosity(0)

--- a/python/pyhrf/validation/valid_jde_vem_asl.py
+++ b/python/pyhrf/validation/valid_jde_vem_asl.py
@@ -7,7 +7,11 @@ import logging
 
 import numpy as np
 
-from sklearn.externals.joblib import Memory
+try:
+    from sklearn.externals.joblib import Memory
+except ImportError:
+    def Memory(*args, **kwargs):
+        pass
 
 import pyhrf
 

--- a/snap_default.sh
+++ b/snap_default.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-cp MANIFEST.default MANIFEST.in && python setup.py sdist
-

--- a/snap_default_tag_date.sh
+++ b/snap_default_tag_date.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-cp MANIFEST.default MANIFEST.in && python setup.py egg_info --tag-date sdist


### PR DESCRIPTION
The commit message of 22de134e8a052ec287027de9af45eb4184f1e151 should be `[#104] Automatic non-graphical backend for matplotlib when $DISPLAY environment variable is not set`.
My terminal replaced the `$DISPLAY` enviroment variable by its value: `:0`