### PR TITLE
pip 10.0.1 parse_requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,8 @@ def setup_package():
             from pip._internal.req import parse_requirements
         except ImportError: # for pip <= 9.0.3
             from pip.req import parse_requirements
-
+        import pip
+        
         # Dependencies for building C Extensions
         try:
             dependencies = list(parse_requirements('requirements.txt'))

--- a/setup.py
+++ b/setup.py
@@ -40,14 +40,17 @@ def setup_package():
     else:
         from setuptools import find_packages, Extension
         from glob import glob
-        import pip
+        try: # for pip >= 10
+            from pip._internal.req import parse_requirements
+        except ImportError: # for pip <= 9.0.3
+            from pip.req import parse_requirements
 
         # Dependencies for building C Extensions
         try:
-            dependencies = list(pip.req.parse_requirements('requirements.txt'))
+            dependencies = list(parse_requirements('requirements.txt'))
         except TypeError:
             # new versions of pip requires a session
-            dependencies = list(pip.req.parse_requirements('requirements.txt', session=pip.download.PipSession()))
+            dependencies = list(parse_requirements('requirements.txt', session=pip.download.PipSession()))
 
         dependencies = [str(package.req) for package in dependencies]
 


### PR DESCRIPTION
If using pip >= 10.0.1 the "req" module has been moved.  Added changes check the user pip version and imports parse_requirements.

This came about because I continued to get the error: 

Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-dos34K/pyhrf/setup.py", line 117, in <module>
        setup_package()
      File "/tmp/pip-install-dos34K/pyhrf/setup.py", line 47, in setup_package
        dependencies = list(pip.req.parse_requirements('requirements.txt'))
AttributeError: 'module' object has no attribute 'req'

I was using pip version 10.0.1, and once I reverted to version 9.0.3 the error was resolved