### PR TITLE
Unit tests: cleaning-up warnings and errors

### DIFF
--- a/python/pyhrf/boldsynth/scenarios.py
+++ b/python/pyhrf/boldsynth/scenarios.py
@@ -352,6 +352,7 @@ def get_bold_shape(stim_induced_signal, dsf):
 
 
 def calc_asl_shape(bold_stim_induced, dsf):
+    dsf = int(dsf)
     return bold_stim_induced[0:-1:dsf, :].shape
 
 
@@ -795,6 +796,7 @@ def create_asl_from_stim_induced(bold_stim_induced, perf_stim_induced,
     add noise and drift (nuisance signals) which has to be at downsampled
     temporal resolution.
     """
+    dsf = int(dsf)
     bold = bold_stim_induced[0:-1:dsf, :].copy()
     perf = np.dot(ctrl_tag_mat, (perf_stim_induced[0:-1:dsf, :].copy() +
                                  perf_baseline))

--- a/python/pyhrf/glm.py
+++ b/python/pyhrf/glm.py
@@ -10,7 +10,11 @@ import logging
 
 import scipy as sp
 
-from nipy.labs.glm import glm
+import warnings
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", FutureWarning)
+    from nipy.labs.glm import glm
+
 from nipy.modalities.fmri import design_matrix as dm
 try:
     from nipy.modalities.fmri.experimental_paradigm import \

--- a/python/pyhrf/graph.py
+++ b/python/pyhrf/graph.py
@@ -399,7 +399,7 @@ def connected_components_iter(g):
         g = graph_pygraph(g)
         bfs = bfs_pygraph
     else:
-        logger.warning('Warning: pygraph not available ... fall back to slow BFS function')
+        logger.info('Warning: pygraph not available ... fall back to slow BFS function')
         bfs = breadth_first_search
 
     visited = np.zeros(len(g), dtype=bool)
@@ -418,7 +418,7 @@ def connected_components(g):
         g = graph_pygraph(g)
         bfs = bfs_pygraph
     else:
-        logger.warning('Warning: pygraph not available ... fall back to slow BFS function')
+        logger.info('Warning: pygraph not available ... fall back to slow BFS function')
         bfs = breadth_first_search
 
     if 1:

--- a/python/pyhrf/jde/jde_multi_sujets.py
+++ b/python/pyhrf/jde/jde_multi_sujets.py
@@ -769,7 +769,7 @@ class HRF_Sampler(GibbsSamplerVariable):
         logger.info(self.finalValue)
 
     def getScaleFactor(self):
-        if self.finalValue == None:
+        if self.finalValue is None:
             self.setFinalValue()
         # Use amplitude :
         #scaleF = self.finalValue.max()-self.finalValue.min()
@@ -987,7 +987,7 @@ class HRFVarianceSubjectSampler(GibbsSamplerVariable):
                 raise Exception('Needed a true value for %s init but '
                                 'None defined' % self.name)
 
-        if self.currentValue == None:
+        if self.currentValue is None:
             if not self.sampleFlag and self.dataInput.simulData != None \
                     and self.dataInput.simulData.hrf.hrfParams.has_key('rh'):
                 simulRh = self.dataInput.simulData.hrf.hrfParams['rh']
@@ -1313,7 +1313,7 @@ class HRF_Group_Sampler(GibbsSamplerVariable):
         logger.info(self.finalValue)
 
     def getScaleFactor(self):
-        if self.finalValue == None:
+        if self.finalValue is None:
             self.setFinalValue()
         # Use amplitude :
         #scaleF = self.finalValue.max()-self.finalValue.min()
@@ -2325,7 +2325,7 @@ class BOLDSampler_MultiSujInput:
         logger.debug(availableDataIndex)
 
         # suppose same nb of scans for all subjects
-        lgt = (self.nySubj[0] + 2) * osf
+        lgt = int((self.nySubj[0] + 2) * osf)
         matH = np.zeros((lgt, self.nbConditions), dtype=int)
         for j in xrange(self.nbConditions):
             matH[:len(parData[j]), j] = parData[j][:]

--- a/python/pyhrf/jde/nrl/bigaussian.py
+++ b/python/pyhrf/jde/nrl/bigaussian.py
@@ -876,8 +876,8 @@ class NRLSampler(xmlio.XmlInitable, GibbsSamplerVariable):
         for c in xrange(self.nbClasses):
             ivc = self.voxIdx[c][j]
             logger.info('nrl %s cond %d = %1.3f(%1.3f)', self.CLASS_NAMES[c], j,
-                        self.currentValue[c, ivc].mean(),
-                        self.currentValue[j, ivc].std())
+                self.currentValue[c, ivc].mean() if len(self.currentValue[c, ivc]) else np.nan,
+                self.currentValue[j, ivc].std()  if len(self.currentValue[j, ivc]) else np.nan)
 
     def sampleNrlsParallel(self, varXh, rb, h, varLambda, varCI, varCA,
                            meanCA, gTQg, variables):

--- a/python/pyhrf/parcellation.py
+++ b/python/pyhrf/parcellation.py
@@ -10,7 +10,11 @@ from time import strftime, localtime, time
 
 import numpy as np
 from numpy.random import rand, randint, permutation
-from nipy.labs.spatial_models.parcel_io import fixed_parcellation
+
+import warnings
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", FutureWarning)
+    from nipy.labs.spatial_models.parcel_io import fixed_parcellation
 
 try:
     from nipy.algorithms.clustering.clustering import voronoi

--- a/python/pyhrf/plot.py
+++ b/python/pyhrf/plot.py
@@ -103,7 +103,7 @@ def plot_func_slice(func_slice_data, anatomy=None, parcellation=None,
     anat_cmap = plt.get_cmap('gray')
 
     plt.figure()
-    plt.hold(True)
+    # plt.hold(True) Deprecated function, no longer necessary to call it. 
 
     if anatomy is not None:
         ax = plt.imshow(mix_cmap(func_masked, func_cmap,
@@ -115,13 +115,13 @@ def plot_func_slice(func_slice_data, anatomy=None, parcellation=None,
         ax = plt.imshow(func_masked, cmap=func_cmap,
                         norm=func_norm,
                         interpolation='nearest')
-    ax.get_axes().set_axis_off()
+    ax.axes.set_axis_off()
 
 
     if resolution is not None:
         ratio = resolution[0] / resolution[1]
         print 'Set aspect ratio to:', ratio
-        ax.get_axes().set_aspect(ratio)
+        ax.axes.set_aspect(ratio)
 
     if parcellation is not None:
         labs = np.unique(parcellation)
@@ -187,7 +187,7 @@ def plot_anat_parcel_func_fusion(anat, func, parcel, parcel_col='white',
                                  norm1=func_norm,
                                  norm2=anat_norm, blend_r=.5),
                         interpolation='nearest')
-        ax.get_axes().set_axis_off()
+        ax.axes.set_axis_off()
 
     if 0:
         plt.imshow(func_rebin_ma*anat, interpolation='nearest',

--- a/python/pyhrf/sandbox/physio.py
+++ b/python/pyhrf/sandbox/physio.py
@@ -753,6 +753,8 @@ def  buildOrder1FiniteDiffMatrix_central(size,dt):
     """
     from scipy.linalg import toeplitz
 
+    size = int(size)
+
     r = np.zeros(size)
     c = np.zeros(size)
     r[1] = .5
@@ -811,7 +813,7 @@ def linear_rf_operator(rf_size, phy_params, dt, calculating_brf=False):
 
     from pyhrf.sandbox.physio import buildOrder1FiniteDiffMatrix_central
     D = buildOrder1FiniteDiffMatrix_central(rf_size,dt) #numpy matrix
-    eye = np.matrix(np.eye(rf_size))  #numpy matrix
+    eye = np.matrix(np.eye(int(rf_size)))  #numpy matrix
 
     A3 = tau_m_inv*( (D + (alpha_w_inv*tau_m_inv)*eye).I )
     A4 = c * (D+tau_m_inv*eye).I - (D+tau_m_inv*eye).I*((1-alpha_w)*alpha_w_inv* tau_m_inv**2)* (D+alpha_w_inv*tau_m_inv*eye).I

--- a/python/pyhrf/test/test.py
+++ b/python/pyhrf/test/test.py
@@ -29,4 +29,4 @@ from test_jde_vem_bold import *
 from test_ndarray import *
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main(verbosity=2)


### PR DESCRIPTION
The behaviour of the tests did not change. The following files were
updated to clean-up warnings and errors:

python/pyhrf/boldsynth/scenarios.py
python/pyhrf/sandbox/physio.py
python/pyhrf/jde/jde_multi_sujets.py
    VisibleDeprecationWarning cleanup. Using a non-integer in the place
of an integer will result in an error in the future. So, we call int()
to make sure it will be always an integer and eliminate the warning.

python/pyhrf/graph.py
    Eliminate overly verbose warning that pygraph is not available (from
warning to info). The code is no longer compatible with the only available
version of pygraph (0.2.1) and a refactoring would take some time.

python/pyhrf/test/test.py
    Unittests a bit more verbose to help clean the warning/error messages.

python/pyhrf/plot.py
    Eliminating the call to the deprecated hold function of matplotlib (no
need to call it). Changing 'get_axes' (deprecated) to 'axes' of matplotlib.

python/pyhrf/jde/nrl/bigaussian.py
    Checking slice sizes to avoid numpy RuntimeErrors, maintaining the same
behaviour.

python/pyhrf/jde/jde_multi_sujets.py
    Removing FutureWarning: proper way to compare to None is 'is None', not
'== None'.

python/pyhrf/glm.py
python/pyhrf/parcellation.py
    Ignoring FutureWarnings from nipy. Deprecation messages are more than
4-year old, and we probably won't update nipy version before changing to
Python 3...